### PR TITLE
Update test coordinates and date formatting culture

### DIFF
--- a/FlagsRally_xunit/FlagsRally_xunit/CustomGeolocationTests.cs
+++ b/FlagsRally_xunit/FlagsRally_xunit/CustomGeolocationTests.cs
@@ -75,7 +75,7 @@ public class CustomGeolocationTests
     public async Task Generate_location_data_from_location_coordinates_in_other_2()
     {
         // Arrange
-        Location location = new Location(12.984305, -61.287228);
+        Location location = new Location(13.0109, -61.2357);
         string languageCode = "ja";
         var preferencesMock = new Mock<IPreferences>();
         preferencesMock.Setup(p => p.Get<string>("ApiKey", string.Empty, null)).Returns(Constants.GOOGLE_MAP_API_KEY);

--- a/FlagsRally_xunit/FlagsRally_xunit/CustomLocationTests.cs
+++ b/FlagsRally_xunit/FlagsRally_xunit/CustomLocationTests.cs
@@ -118,7 +118,7 @@ public class CustomLocationTests
         );
 
         // Assert
-        Assert.Equal(arrivalDate.ToString("dd MMM yyyy"), customLocation.ArrivalDateString);
+        Assert.Equal(arrivalDate.ToString("dd  MMM  yyyy", CultureInfo.CreateSpecificCulture("en-US")), customLocation.ArrivalDateString);
     }
 
     [Fact]


### PR DESCRIPTION
- Changed location coordinates in `CustomGeolocationTests`.
- Updated date formatting to use "en-US" culture in `CustomLocationTests`.