### PR TITLE
Initialize FilteredCustomBoard if null

### DIFF
--- a/ViewModels/CustomBoardPageViewModel.cs
+++ b/ViewModels/CustomBoardPageViewModel.cs
@@ -68,7 +68,10 @@ public partial class CustomBoardPageViewModel : BaseViewModel
 
             var allBoards = await _customBoardRepository.GetAllCustomBoards();
             CustomBoardList = new ObservableCollection<CustomBoard>(allBoards);
+            if (FilteredCustomBoard is null)
+            {
             FilteredCustomBoard = allBoards.First();
+            }
 
             var allCustomLocations = await _customLocationDataRepository.GetAllCustomLocations();
             SourceCustomLocationList = new ObservableCollection<CustomLocation>(allCustomLocations);


### PR DESCRIPTION
Added a check to assign the first custom board to
FilteredCustomBoard if it is null after retrieving all custom boards. This improves the initialization logic in the CustomBoardPageViewModel class.