### PR TITLE
Add SVG support with FFImageLoading and IsSvgUrlConverter

### DIFF
--- a/Converters/IsSvgUrlConverter.cs
+++ b/Converters/IsSvgUrlConverter.cs
@@ -1,0 +1,21 @@
+using System.Globalization;
+
+namespace FlagsRally.Converters
+{
+    public class IsSvgUrlConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is string url && !string.IsNullOrEmpty(url))
+            {
+                return url.EndsWith(".svg", StringComparison.OrdinalIgnoreCase);
+            }
+            return false;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/FlagsRally.csproj
+++ b/FlagsRally.csproj
@@ -629,6 +629,7 @@
 		<PackageReference Include="CommunityToolkit.Maui" Version="11.2.0" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
 		<PackageReference Include="CountryData.Standard" Version="1.5.0" />
+		<PackageReference Include="FFImageLoading.Maui" Version="1.3.2" />
 		<PackageReference Include="Kebechet.Maui.RevenueCat.InAppBilling" Version="5.0.0" />
 		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.100" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.100" />

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -8,6 +8,7 @@ using Maui.GoogleMaps.Hosting;
 using Maui.RevenueCat.InAppBilling;
 using Microsoft.Extensions.Logging;
 using Syncfusion.Maui.Core.Hosting;
+using FFImageLoading.Maui;
 
 namespace FlagsRally
 {
@@ -20,6 +21,7 @@ namespace FlagsRally
                 .UseMauiApp<App>()
                 .ConfigureSyncfusionCore()
                 .UseMauiCommunityToolkit()
+                .UseFFImageLoading()
                 .ConfigureFonts(fonts =>
                 {
                     fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");

--- a/Views/CustomBoardPage.xaml
+++ b/Views/CustomBoardPage.xaml
@@ -5,13 +5,16 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:converters="clr-namespace:FlagsRally.Converters"
     xmlns:customboard="clr-namespace:FlagsRally.Models.CustomBoard"
+    xmlns:ff="clr-namespace:FFImageLoading.Maui;assembly=FFImageLoading.Maui"
     xmlns:map="clr-namespace:Syncfusion.Maui.Maps;assembly=Syncfusion.Maui.Maps"
+    xmlns:mct="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
     xmlns:models="clr-namespace:FlagsRally.Models"
     xmlns:strings="clr-namespace:FlagsRally.Resources"
     xmlns:viewmodels="clr-namespace:FlagsRally.ViewModels"
     x:DataType="viewmodels:CustomBoardPageViewModel">
     <ContentPage.Resources>
         <converters:BoardFontSizeConverter x:Key="FontSizeConverter" />
+        <converters:IsSvgUrlConverter x:Key="IsSvgUrlConverter" />
     </ContentPage.Resources>
     <Grid Padding="5" RowSpacing="10">
         <Grid.RowDefinitions>
@@ -98,17 +101,26 @@
                                                          iOS=2,
                                                          Default=0}"
                                     VerticalOptions="Center">
-                                    <Image
-                                        Aspect="AspectFit"
-                                        HorizontalOptions="Center"
-                                        VerticalOptions="Center">
-                                        <Image.Source>
-                                            <UriImageSource
-                                                CacheValidity="30"
-                                                CachingEnabled="True"
-                                                Uri="{Binding ImageUrl}" />
-                                        </Image.Source>
-                                    </Image>
+                                    <Grid>
+                                        <ff:SvgCachedImage
+                                            Aspect="AspectFit"
+                                            CacheDuration="30"
+                                            CacheType="Memory"
+                                            IsVisible="{Binding ImageUrl, Converter={StaticResource IsSvgUrlConverter}}"
+                                            Source="{Binding ImageUrl}" />
+                                        <Image
+                                            Aspect="AspectFit"
+                                            HorizontalOptions="Center"
+                                            IsVisible="{Binding ImageUrl, Converter={StaticResource IsPngUrlConverter}}"
+                                            VerticalOptions="Center">
+                                            <Image.Source>
+                                                <UriImageSource
+                                                    CacheValidity="30"
+                                                    CachingEnabled="True"
+                                                    Uri="{Binding ImageUrl}" />
+                                            </Image.Source>
+                                        </Image>
+                                    </Grid>
                                     <StackLayout BackgroundColor="Black">
                                         <Label
                                             FontFamily="KiwiMaru-Medium"


### PR DESCRIPTION
Enhanced image handling by integrating FFImageLoading.Maui for SVG support. Added `IsSvgUrlConverter` to determine if a URL points to an SVG file. Updated `CustomBoardPage.xaml` to conditionally render SVG and non-SVG images using `SvgCachedImage` and standard `<Image>` elements.

Modified `MauiProgram.cs` to include `UseFFImageLoading()` and updated `FlagsRally.csproj` to add the FFImageLoading.Maui package. Improved project configuration to handle both SVG and non-SVG images dynamically.