### PR TITLE
Update Android minimum supported version to 35

### DIFF
--- a/FlagsRally.csproj
+++ b/FlagsRally.csproj
@@ -31,7 +31,7 @@
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">30</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">35</SupportedOSPlatformVersion>
 		<DefaultLanguage>en-us</DefaultLanguage>
 		<NeutralLanguage>en</NeutralLanguage>
 	</PropertyGroup>


### PR DESCRIPTION
The `SupportedOSPlatformVersion` for the Android platform in the `FlagsRally.csproj` file was updated from `30` to `35`. This change increases the minimum supported Android platform version for the project.