### PR TITLE
Update dependencies and add Android-specific package

### DIFF
--- a/FlagsRally.csproj
+++ b/FlagsRally.csproj
@@ -629,7 +629,7 @@
 		<PackageReference Include="CommunityToolkit.Maui" Version="11.2.0" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
 		<PackageReference Include="CountryData.Standard" Version="1.5.0" />
-		<PackageReference Include="Kebechet.Maui.RevenueCat.InAppBilling" Version="5.0.0" />
+		<PackageReference Include="Kebechet.Maui.RevenueCat.InAppBilling" Version="5.3.2" />
 		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.100" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.100" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.8" />
@@ -638,7 +638,7 @@
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="Onion.Maui.GoogleMaps" Version="6.2.0" />
-		<PackageReference Include="SkiaSharp.Extended.UI.Maui" Version="3.0.0-preview.18" />
+		<PackageReference Include="SkiaSharp.Extended.UI.Maui" Version="3.0.0" />
 		<PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
 		<PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.11" />
 		<PackageReference Include="SQLitePCLRaw.core" Version="3.0.2" />
@@ -1232,5 +1232,11 @@
 	  <MauiFont Update="Resources\Fonts\KiwiMaru-Medium.ttf">
 	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
 	  </MauiFont>
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0-android'">
+	  <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData">
+	    <Version>2.9.1</Version>
+	  </PackageReference>
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Updated `Kebechet.Maui.RevenueCat.InAppBilling` to version `5.3.2` and `SkiaSharp.Extended.UI.Maui` to stable version `3.0.0`. Added `Xamarin.AndroidX.Lifecycle.LiveData` (v2.9.1) under a new `ItemGroup` for the `net9.0-android` target framework to support Android-specific functionality.