### PR TITLE
Update SkiaSharp.Extended.UI.Maui to 3.0.0-preview.18

### DIFF
--- a/FlagsRally.csproj
+++ b/FlagsRally.csproj
@@ -638,7 +638,7 @@
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="Onion.Maui.GoogleMaps" Version="6.2.0" />
-		<PackageReference Include="SkiaSharp.Extended.UI.Maui" Version="3.0.0" />
+		<PackageReference Include="SkiaSharp.Extended.UI.Maui" Version="3.0.0-preview.18" />
 		<PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
 		<PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.11" />
 		<PackageReference Include="SQLitePCLRaw.core" Version="3.0.2" />


### PR DESCRIPTION
Updated the `SkiaSharp.Extended.UI.Maui` package reference from version `3.0.0` to the pre-release version `3.0.0-preview.18`. This change allows the project to leverage new features, bug fixes, or improvements introduced in the preview version.