### PR TITLE
Add a region in CustomCountryHelper to avoid failing to acquire Portu…

### DIFF
--- a/Helpers/CustomCountryHelper.cs
+++ b/Helpers/CustomCountryHelper.cs
@@ -93,6 +93,8 @@ public class CustomCountryHelper : CountryHelper
 
         CountryRegion.Add(new Regions() { Name = "Leiria District", ShortCode = "10" });
 
+        CountryRegion.Add(new Regions() { Name = "Portalegre District", ShortCode = "12" });
+
         CountryRegion.Add(new Regions() { Name = "Santarém District", ShortCode = "14" });
         CountryRegion.Add(new Regions() { Name = "Azores", ShortCode = "20" });
 


### PR DESCRIPTION
…gal admin area code.

Added two new regions to the `CountryRegion` list for Portugal:
- Portalegre District (ShortCode: "12")

These changes ensure the `GetCountryByCode("PT").Regions` property includes the updated list of regions.