### PR TITLE
Fix typo in OverwriteExistingFile resource string

### DIFF
--- a/Resources/AppResources.Designer.cs
+++ b/Resources/AppResources.Designer.cs
@@ -538,7 +538,7 @@ namespace FlagsRally.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This operation over write the existing file..
+        ///   Looks up a localized string similar to This operation overwrites the existing file..
         /// </summary>
         internal static string OverwriteExistingFile {
             get {

--- a/Resources/AppResources.resx
+++ b/Resources/AppResources.resx
@@ -235,7 +235,7 @@
     <value>No duplicate countries</value>
   </data>
   <data name="OverwriteExistingFile" xml:space="preserve">
-    <value>This operation over write the existing file.</value>
+    <value>This operation overwrites the existing file.</value>
   </data>
   <data name="PayWallSubTitle" xml:space="preserve">
     <value>The first 3 months are free for new subscribers.</value>


### PR DESCRIPTION
Corrected a grammatical error in the `OverwriteExistingFile` localized string. Updated the summary comment in
`AppResources.Designer.cs` and the resource value in `AppResources.resx` from "This operation over write the existing file." to "This operation overwrites the existing file." for consistency and clarity. No functional changes were made.