### PR TITLE
Remove BackupInstruction resource and fix typo in Instruciton1

### DIFF
--- a/Resources/AppResources.Designer.cs
+++ b/Resources/AppResources.Designer.cs
@@ -142,15 +142,6 @@ namespace FlagsRally.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Please select a folder in the Download folder..
-        /// </summary>
-        internal static string BackupInstruction {
-            get {
-                return ResourceManager.GetString("BackupInstruction", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Backup saved successfully!.
         /// </summary>
         internal static string BackupSucceeded {
@@ -401,9 +392,9 @@ namespace FlagsRally.Resources {
                 return ResourceManager.GetString("Information", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to 1. Got to "Settings" and set your Country of Residence..
+        ///   Looks up a localized string similar to 1. Got to ”Settings” and set your Country of Residence..
         /// </summary>
         internal static string Instruciton1 {
             get {

--- a/Resources/AppResources.ja.resx
+++ b/Resources/AppResources.ja.resx
@@ -135,9 +135,6 @@
   <data name="Backup" xml:space="preserve">
     <value>バックアップ</value>
   </data>
-  <data name="BackupInstruction" xml:space="preserve">
-    <value>Download フォルダ内のフォルダを選択してください。</value>
-  </data>
   <data name="BackupSucceeded" xml:space="preserve">
     <value>バックアップが正常に保存されました。</value>
   </data>

--- a/Resources/AppResources.resx
+++ b/Resources/AppResources.resx
@@ -135,9 +135,6 @@
   <data name="Backup" xml:space="preserve">
     <value>Backup</value>
   </data>
-  <data name="BackupInstruction" xml:space="preserve">
-    <value>Please select a folder in the Download folder.</value>
-  </data>
   <data name="BackupSucceeded" xml:space="preserve">
     <value>Backup saved successfully!</value>
   </data>

--- a/Views/SettingPage.xaml
+++ b/Views/SettingPage.xaml
@@ -146,14 +146,6 @@
                 HorizontalOptions="Start"
                 Text="{x:Static strings:AppResources.Backup}"
                 VerticalOptions="Center" />
-            <Label
-                Padding="10,0"
-                FontAttributes="Bold"
-                FontSize="Small"
-                HorizontalOptions="Start"
-                Text="{x:Static strings:AppResources.BackupInstruction}"
-                TextColor="Red"
-                VerticalOptions="Center" />
             <Button
                 Margin="10,0"
                 Command="{Binding CreateBackUpCommand}"


### PR DESCRIPTION
Removed the `BackupInstruction` string resource from `AppResources.Designer.cs`, `AppResources.ja.resx`, and `AppResources.resx`, as it is no longer needed.

Fixed a typographical error in the `Instruciton1` string resource by replacing straight quotes with smart quotes around "Settings."

Removed the `<Label>` element in `SettingPage.xaml` that referenced the `BackupInstruction` string, simplifying the UI.